### PR TITLE
Add links to the vim plugin for XCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you are looking for a quick programming reference, check out the
 
 If you want to explore the video tutorial, check out the [tutorial guide](TUTORIAL.md).
 
-For development, the recommended IDE is [Atom](https://atom.io) with the [language-xci](https://atom.io/packages/language-xci) package installed.
+For development, the recommended IDE is [Atom](https://atom.io) with the [language-xci](https://atom.io/packages/language-xci) package installed.  There is also [vim](https://www.vim.org) syntax support with the [vim-xci](https://github.com/jestin/vim-xci) syntax plugin.
 
 Finally, if you want to read a complete, in-depth look at how the example game
 was created, see the [configuration walkthrough appendix to this document](example/APPENDIX.md).

--- a/XCI_SYNTAX.md
+++ b/XCI_SYNTAX.md
@@ -13,7 +13,7 @@ For each key, the value format will be described by a set of argument names. Arg
 
 This document is intended to be a concise guide to the language and not a comprehensive programmer's guide. For that, please see the [main documentation](README.md) and the example game [appendix](example/APPENDIX.md).
 
-For development, the recommended IDE is [Atom](https://atom.io) with the [language-xci](https://atom.io/packages/language-xci) package installed.
+For development, the recommended IDE is [Atom](https://atom.io) with the [language-xci](https://atom.io/packages/language-xci) package installed.  There is also [vim](https://www.vim.org) syntax support with the [vim-xci](https://github.com/jestin/vim-xci) syntax plugin.
 
 ## Types
 


### PR DESCRIPTION
When I saw there was an Atom syntax package for XCI, I couldn't help but make a vim syntax plugin as well.  I think this is something nice to add to the XCI README and syntax documentation.