### PR TITLE
OS X: Rename wait struct to xci_wait

### DIFF
--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,10 +1,11 @@
 ALL_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
 ALL_HDRS = $(wildcard *.h)
+GCC_CMD = gcc
 
 all: $(ALL_OBJS) $(ALL_HDRS) dev_tools
-	gcc -o xci.exe $(ALL_OBJS)
+	$(GCC_CMD) -o xci.exe $(ALL_OBJS)
 %.o: %.c
-	gcc -c $< -o $@
+	$(GCC_CMD) -c $< -o $@
 
 clean:
 	rm -f xci.exe $(ALL_OBJS)
@@ -13,10 +14,10 @@ clean:
 test: bitmap_test music_test
 
 bitmap_test: bitmap.h bitmap.c
-	gcc -o bitmap.exe -DTEST bitmap.c
+	$(GCC_CMD) -o bitmap.exe -DTEST bitmap.c
 
 music_test: vgm2x16opm.h vgm2x16opm.c
-	gcc -o music.exe -DTEST vgm2x16opm.c
+	$(GCC_CMD) -o music.exe -DTEST vgm2x16opm.c
 
 dev_tools:
 	$(MAKE) -C tools

--- a/sdk/animation.h
+++ b/sdk/animation.h
@@ -38,7 +38,7 @@ typedef struct sprite_move {
    uint8_t y;
 } sprite_move_t;
 
-typedef struct wait {
+typedef struct xci_wait {
    uint8_t key; // must be xci_key_t::WAIT
    uint8_t jiffys;
 } wait_t;


### PR DESCRIPTION
This avoids conflict with OS X SDK when building under X tools' gcc

The vestigial Makefile change is unrelated; debated on removing it.

`kyle@Kyles-MacBook-Air sdk % make
gcc -c animation.c -o animation.o
In file included from animation.c:4:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:66:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/wait.h:194:1: error: 
      use of 'wait' with tag type that does not match previous declaration
union wait {
^
./animation.h:41:16: note: previous use is here
typedef struct wait {
               ^
In file included from animation.c:4:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:66:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/wait.h:194:7: error: 
      redefinition of 'wait'
union wait {
      ^
./animation.h:41:16: note: previous definition is here
typedef struct wait {
               ^
2 errors generated.
make: *** [animation.o] Error 1`