### PR TITLE
Fix music playing too slow

### DIFF
--- a/engine/music.asm
+++ b/engine/music.asm
@@ -116,6 +116,7 @@ music_tick:
    bra @write
 @delay:
    lda (MUSIC_PTR),y
+   dec a
    sta __music_delay
    INC_MUSIC_PTR
    bra @return


### PR DESCRIPTION
Since the delay between storing the delay value and the next check of it is one frame long, this will make the actual delay being one frame longer than it should. This one line addition will compensate for it.