### PR TITLE
Added multi-revision support in single x16.inc file

### DIFF
--- a/engine/x16.inc
+++ b/engine/x16.inc
@@ -5,14 +5,16 @@ X16_INC  = 1
 __CX16__ = 1
 .endif
 
+__REVDEFAULT__ = 38
+
 .ifdef REV
-	.if REV = 38
-		VERSION := 38
+	.if REV = 39
+		X16_VERSION := 39
 	.else
-		VERSION := 39
+		X16_VERSION := __REVDEFAULT__
 	.endif
 .else
-	VERSION := 39
+	X16_VERSION := __REVDEFAULT__
 .endif
 
 
@@ -119,7 +121,7 @@ VERA_audio_data   = $9F3D
 VERA_spi_data     = $9F3E
 VERA_spi_ctrl     = $9F3F
 
-.if VERSION = 38
+.if X16_VERSION = 38
 	ROM_BANK          = $9F60
 	RAM_BANK          = $9F61
 


### PR DESCRIPTION
Allows a single .inc file to work for projects that aim to have conditional support for both R38 and R39 without having to .include multiple versions of x16.inc.

use --asm-define REV=38 or --asm-define REV=39 to utilize the feature. It produces a symbol X16_VERSION with 38 or 39.
38 is the default.